### PR TITLE
배포: EC2 환경에 맞춰 데이터베이스 URL 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,9 +5,9 @@ spring:
       on-profile: prod
 
   datasource:
-    url: jdbc:mysql://127.0.0.1:3306/switching?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: ENC(yhBPOVyxa8HqITOkczZUVY4UVNhMRxIcq/ut3e58srd/eF7ObPS+iuvvPnIg54NcGtlGx2ECLcc1Q1B9Du2YYW8kHcjmayp1E+2w4ALAjr6SaF7yn07QWLDrvIwpsdRZnF5nhFUhsCXdmJXlQtWU7hzeiT3AdGjIbrkobnUtbRIl6QwF0dWWG7E1sE44g5A4N5ptqGxg/LrUYqOxmr3AfA==)
     username: root
-    password: rltmddn7!
+    password: ENC(ML7LDK3JNhuxprFonh6cJCz9kGRRuRK4)
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
배포: EC2 환경에 맞춰 데이터베이스 URL 수정
- EC2에서 MySQL 대신 AWS RDS를 사용하도록 데이터베이스 연결 URL을 변경
- 기존 로컬 MySQL 연결 URL에서 AWS RDS URL로 변경