### PR TITLE
FIX: CI 스크립트가 ./gradlew 파일이 실행 권한(executable permission)이 없어서 오류발생

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,6 +20,9 @@ jobs:
           distribution: 'temurin' # OpenJDK 배포판 중 하나인 Temurin 사용
           java-version: '17'      # Java 17 버전 설치
 
+      - name: Give gradlew permission
+        run: chmod +x ./gradlew
+
       - name: Build with Gradle
         run: ./gradlew clean build
         # Gradle 빌드 실행 (clean: 기존 빌드 파일 삭제, build: 새로 빌드 생성)


### PR DESCRIPTION
GitHub Actions 스크립트에서 chmod 명령어로 실행 권한을 부여