### PR TITLE
FIX: git actions 스크립트 일부 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,13 +39,6 @@ jobs:
           cd deploy-package
           zip -r deploy.zip .  # deploy.zip 생성
 
-      # AWS CLI 설치
-      - name: Install AWS CLI
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
-
       # AWS 자격 증명 설정 (Secrets에 저장된 값 사용)
       - name: Configure AWS credentials
         run: |


### PR DESCRIPTION
GitHub Actions 가상 환경에는 기본적으로 AWS CLI가 이미 설치가 되어있다고 함.
다시 설치하려 했기 때문에 충돌이 남.