### PR TITLE
FIX: 배포 오류로 인한 git actions 스크립트 일부 변경

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,67 +2,44 @@ name: Deploy Spring Boot to AWS
 
 on:
   push:
-    branches: [ main ]  # main 브랜치에 push 될 때마다 이 워크플로우가 실행됨
+    branches: [ main ]
 
 jobs:
   build-and-upload:
-    runs-on: ubuntu-latest  # GitHub에서 제공하는 최신 Ubuntu 가상환경에서 실행
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        # 현재 리포지토리의 코드를 체크아웃 (가져오기) 해서 다음 단계에서 사용할 수 있게 함
 
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'  # OpenJDK 배포판 중 하나인 Temurin 사용
-          java-version: '17'       # Java 17 버전 설치
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Give gradlew permission
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
         run: ./gradlew clean build
-        # Gradle 빌드 실행 (clean: 기존 빌드 파일 삭제, build: 새로 빌드 생성)
-        # 결과물은 보통 build/libs 디렉토리에 생성됨
 
       - name: Rename jar for deployment
         run: mv build/libs/*.jar build/libs/app.jar
-        # S3에 업로드할 때 파일명을 고정하기
 
-      - name: Create deploy-package directory  # 배포 디렉토리 생성
-        run: mkdir -p deploy-package
-        # CodeDeploy용 디렉토리 생성
-
-      - name: Copy deploy files to deploy-package  # deploy-package에 파일 복사
+      - name: Copy deploy files to root
         run: |
-          cp appspec.yml deploy-package/        # 루트에서 appspec.yml 복사
-          cp clean-up.sh deploy-package/  # scripts 폴더에서 clean-up.sh 복사
-          cp start.sh deploy-package/    # scripts 폴더에서 start.sh 복사
-          cp build/libs/app.jar deploy-package/  # 빌드된 app.jar 복사
+          cp build/libs/app.jar ./
+          cp start.sh ./
+          cp clean-up.sh ./
+          cp appspec.yml ./
 
-      - name: Zip deploy package
-        run: zip -r app.zip deploy-package
+      - name: Zip deployment package
+        run: zip -r app.zip app.jar start.sh clean-up.sh appspec.yml
 
       - name: Upload to S3
         run: aws s3 cp app.zip s3://switching-bucket-202504/app.zip
-
         env:
-          AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}  # S3 버킷 이름
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}  # AWS IAM 액세스 키
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}  # AWS IAM 비밀 키
-          AWS_REGION: ${{ secrets.AWS_REGION }}  # S3 버킷이 있는 AWS 리전
-          SOURCE_DIR: deploy-package  # S3에 업로드할 디렉토리
-
-      - name: Trigger CodeDeploy deployment
-        run: |
-          aws deploy create-deployment \
-            --application-name "switching-ec2-app" \
-            --deployment-group-name "switching-deploy-group" \
-            --revision "revisionType=S3,s3Location={bucket=switching-bucket-202504,key=app.zip,bundleType=zip}" \
-            --deployment-config-name "CodeDeployDefault.AllAtOnce"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}  # AWS IAM 액세스 키
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}  # AWS IAM 비밀 키
-          AWS_REGION: ${{ secrets.AWS_REGION }}  # AWS 리전
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ap-northeast-2


### PR DESCRIPTION
app.zip
└── deploy-package/
    ├── app.jar
    ├── start.sh
    ├── clean-up.sh
    └── appspec.yml

배포 압축 구조가 잘못되어 있었음!

app.zip
├── app.jar
├── start.sh
├── clean-up.sh
└── appspec.yml

CodeDeploy는 압축을 풀었을 때 appspec.yml과 스크립트들이 최상위(root)에 있어야 작동해.
