### PR TITLE
FIX: git actions 스크립트 일부 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,21 +27,23 @@ jobs:
       - name: Rename jar for deployment
         run: mv build/libs/*.jar build/libs/app.jar
 
-      - name: Copy deploy files to deploy-package
+      - name: Prepare deploy-package directory
         run: |
+          rm -rf deploy-package
+          mkdir -p deploy-package
           cp appspec.yml deploy-package/
           cp start.sh deploy-package/
           cp clean-up.sh deploy-package/
-          cp build/libs/app.jar deploy-package/  # <- 이거 중요!
+          cp build/libs/app.jar deploy-package/
 
       - name: Zip for deployment
-        run: zip -r app.zip *  # 또는 zip -r app.zip ./* (deploy-package 내부에서)
-        working-directory: deploy-package
+        run: |
+          cd deploy-package
+          zip -r ../app.zip ./*
 
       - name: Upload to S3
         run: aws s3 cp app.zip s3://switching-bucket-202504/app.zip
         env:
-          AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -51,8 +53,10 @@ jobs:
           aws deploy create-deployment \
             --application-name "switching-ec2-app" \
             --deployment-group-name "switching-deploy-group" \
-            --revision "revisionType=S3,s3Location={bucket=switching-bucket-202504,key=app.zip,bundleType=zip}" \
-            --deployment-config-name "CodeDeployDefault.AllAtOnce"
+            --revision type=S3,bucket=switching-bucket-202504,key=app.zip \
+            --deployment-config-name CodeDeployDefault.AllAtOnce \
+            --description "Deploy triggered by GitHub Actions" \
+            --region ${{ secrets.AWS_REGION }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
🔥 현재 문제 요약
1. deploy-package 디렉토리가 없는데 cp로 복사하려 해서 실패할 수 있음.
2. app.jar을 build/libs/app.jar로 복사했지만, zip 해제 후에도 여전히 그 경로 안에 있음.
3. EC2에서 S3에서 app.jar을 루트 경로에서 찾으려고 하니 못 찾음.
4. zip -r app.zip * 하면 deploy-package 내부 구조를 유지해버림 (하위 폴더 포함).