### PR TITLE
Feature/codedeploy

### DIFF
--- a/src/main/java/com/switching/study_matching_site/jwt/JWTFilter.java
+++ b/src/main/java/com/switching/study_matching_site/jwt/JWTFilter.java
@@ -38,7 +38,10 @@ public class JWTFilter extends OncePerRequestFilter {
         // 로그인, 회원가입, 토큰 재발급 경로는 JWT 필터를 거치지 않도록 설정
         if (requestURI.equals("/login") ||
                 requestURI.equals("/members") ||
-                requestURI.equals("/reissue")) {
+                requestURI.equals("/reissue") ||
+                requestURI.startsWith("/swagger-ui") ||
+                requestURI.startsWith("/v3/api-docs") ||
+                requestURI.startsWith("/swagger-resources")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/switching/study_matching_site/jwt/JWTFilter.java
+++ b/src/main/java/com/switching/study_matching_site/jwt/JWTFilter.java
@@ -41,7 +41,8 @@ public class JWTFilter extends OncePerRequestFilter {
                 requestURI.equals("/reissue") ||
                 requestURI.startsWith("/swagger-ui") ||
                 requestURI.startsWith("/v3/api-docs") ||
-                requestURI.startsWith("/swagger-resources")) {
+                requestURI.startsWith("/swagger-resources") ||
+                requestURI.startsWith("/rooms")) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
SecurityConfig에서는 Spring Security의 보안 설정을 담당하고, 주로 인증(로그인)과 인가(권한 부여)를 다룬다. 
SecurityConfig에서 화이트 리스트를 설정하는 이유는 어떤 경로에 대해 인증 없이 접근할 수 있도록 허용하는 것이다. 
예를 들어, API 문서(swagger-ui), 로그인, 회원가입 등은 보통 인증을 필요로 하지 않으니까 화이트 리스트에 넣어서 인증 없이 접근할 수 있도록 한다. SecurityConfig에서 화이트 리스트 설정은 주로 인증 전에 이루어지는 일이기 때문에, 로그인 전에 접근할 수 있는 경로들을 설정하는 것이다.

JWTFilter는 JWT 토큰을 검사하는 필터이다. 
인증(로그인)을 담당하는 필터로, 요청에 포함된 JWT 토큰을 확인하고 유효한지 검사하고 있다. 
그러나 모든 요청에 대해서 토큰을 검사하면 불필요한 연산이 발생할 수 있기 때문에, 토큰 검증을 제외할 경로들(화이트 리스트)을 설정해줘야 한다.

🤔 왜 두 군데에서 화이트 리스트를 설정해야 할까?
👉 SecurityConfig와 JWTFilter 각각의 역할이 다르기 때문에 두 군데에서 모두 화이트 리스트를 설정해야 한다. 

1) SecurityConfig의 화이트 리스트
이곳은 인증(로그인)과 인가(권한 부여)를 담당하므로, 어떤 경로는 인증 없이 접근할 수 있는지를 설정하는 곳이다.
예를 들어, 로그인, 회원가입, 또는 공개된 API 문서 같은 인증 없이 접근할 수 있어야 하는 경로들에 대한 설정을 한다.

2) JWTFilter의 화이트 리스트
JWTFilter는 인증 정보가 담긴 JWT를 검사하는 역할을 한다. 
이 필터는 기본적으로 모든 요청에 대해 JWT 검사를 해야 하지만, 인증을 거치지 않아도 되는 경로에서는 JWT 검사를 건너뛰어야 한다.
JWT 필터의 화이트 리스트는 JWT 검사를 하지 않아야 할 경로를 설정하는 것이다. JWT 필터는 여전히 그 경로를 지나면서 토큰이 있는지 확인하려 할 수 있기 때문에, 이를 방지하려면 JWTFilter 내부에서 화이트 리스트를 설정해야 한다.

결론
SecurityConfig에서 설정한 permitAll() 경로들은 인증을 건너뛰는 경로이므로, JWT 토큰을 검사하지 않도록 설정해야 한다.
JWTFilter에서도 화이트리스트를 설정해야 하는 이유는 JWTFilter가 인증과 관계없이 모든 요청을 처리하려고 하기 때문이다. 
그래서 SecurityConfig에서 permitAll()으로 허용된 경로에서도 JWT 필터가 실행되지 않도록 하기 위해 화이트리스트가 필요하다.