### PR TITLE
Jacoco Report Actions 버전 변경

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./gradlew jacocoTestReport
 
       - name: Upload JaCoCo Report as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jacoco-report
           path: build/reports/jacoco/test/html


### PR DESCRIPTION
GitHub이 2024년 4월에 actions/upload-artifact@v3 버전을 deprecated 처리. 
그래서 v3를 쓰면 자동으로 실패하게 됨 → v4로 버전 변경